### PR TITLE
In fc23 dracut has moved to /usr/bin

### DIFF
--- a/kernel.spec
+++ b/kernel.spec
@@ -322,7 +322,7 @@ mv  %buildroot/lib/firmware-all %buildroot/lib/firmware/%kernelrelease
 
 # Prepare initramfs for Qubes VM
 mkdir -p %buildroot/%vm_install_dir
-/sbin/dracut --nomdadmconf --nolvmconf \
+PATH="/sbin:$PATH" dracut --nomdadmconf --nolvmconf \
     --kmoddir %buildroot/lib/modules/%kernelrelease \
     --modules "kernel-modules qubes-vm-simple" \
     --conf /dev/null --confdir /var/empty \


### PR DESCRIPTION
Use PATH to find the binary so we continue to work for older versions.