### PR TITLE
rpm: set default kernel version based on package flavor

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -555,13 +555,16 @@ rmdir /tmp/qubes-modules-%kernelrelease
 mv /tmp/qubes-modules-%kernelrelease.img %vm_install_dir/modules.img
 %endif
 
-%if "%{?name_suffix}" == ""
+current_default="$(qubes-prefs default-kernel)"
+current_default_path="/var/lib/qubes/vm-kernels/$current_default"
+current_default_package="$(rpm --qf '%{NAME}' -qf "$current_default_path")"
+if [ "$current_default_package" = "%{name}-qubes-vm" ]; then
 # Set kernel as default VM kernel if we are the default package.
 
 # If qubes-prefs isn't installed yet, the default kernel will be set by %post
 # of qubes-core-dom0
 type qubes-prefs &>/dev/null && qubes-prefs --set default-kernel %version-%plainrel
-%endif
+fi
 
 exit 0
 


### PR DESCRIPTION
If default kernel was from kernel-latest, update default kernel property
on kernel-latest update (only). Same for other kernel package flavor.

Suggested by @hexagonrecursion
Fixes QubesOS/qubes-issues#5309

- [x]  TODO: test

