### PR TITLE
change WireGuard version from 20190702 to 20190913

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 HASH_FILE :=${SRC_FILE}.sha1sum
 
 WG_BASE_URL := https://git.zx2c4.com/WireGuard/snapshot
-WG_SRC_FILE := WireGuard-0.0.20190702.tar.xz
+WG_SRC_FILE := WireGuard-0.0.20190913.tar.xz
 
 WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -96,7 +96,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 ExclusiveArch:  x86_64
 
 Source0:        linux-%version.tar.xz
-Source5:	WireGuard-0.0.20190702.tar.xz
+Source5:	WireGuard-0.0.20190913.tar.xz
 Source16:       guards
 Source17:       apply-patches
 Source33:       check-for-config-changes


### PR DESCRIPTION
straight update
tested and working with 5.2.16 on a fedora-30
