### PR TITLE
update WireGuard from 20190913 to 20191012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ HASH_FILE := $(SRC_FILE).sha512
 endif
 
 WG_BASE_URL := https://git.zx2c4.com/WireGuard/snapshot
-WG_SRC_FILE := WireGuard-0.0.20190913.tar.xz
+WG_SRC_FILE := WireGuard-0.0.20191012.tar.xz
 
 WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -108,7 +108,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 %else
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
-Source5:	WireGuard-0.0.20190913.tar.xz
+Source5:	WireGuard-0.0.20191012.tar.xz
 Source16:       guards
 Source17:       apply-patches
 Source33:       check-for-config-changes


### PR DESCRIPTION
related: https://github.com/QubesOS/qubes-issues/issues/5437