### PR TITLE
Change posttrans script to install grub-efi configuration

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -514,17 +514,16 @@ if [ -f /etc/default/grub ]; then
     fi
 fi
 
-if [ -f /boot/efi/EFI/qubes/xen.cfg ]; then
-    if ! grep -q plymouth.ignore-serial-consoles /boot/efi/EFI/qubes/xen.cfg; then
-        sed -i 's/kernel=.*/& plymouth.ignore-serial-consoles/g' /boot/efi/EFI/qubes/xen.cfg
-    fi
-fi
-
 /bin/kernel-install add %{kernelrelease} /boot/vmlinuz-%{kernelrelease} || exit $?
 
-# grubby (used by new-kernel-pkg) do not understand xen entries in grub2 config
+# Generate legacy boot grub config
 if [ -x /sbin/new-kernel-pkg -a -e /boot/grub2/grub.cfg ]; then
     grub2-mkconfig > /boot/grub2/grub.cfg
+fi
+
+# Generate EFI boot grub config
+if [ -x /sbin/new-kernel-pkg -a -e /boot/efi/EFI/qubes/grub.cfg ]; then
+    grub2-mkconfig > /boot/efi/EFI/qubes/grub.cfg
 fi
 
 %preun

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -514,6 +514,12 @@ if [ -f /etc/default/grub ]; then
     fi
 fi
 
+if [ -f /boot/efi/EFI/qubes/xen.cfg ]; then
+    if ! grep -q plymouth.ignore-serial-consoles /boot/efi/EFI/qubes/xen.cfg; then
+        sed -i 's/kernel=.*/& plymouth.ignore-serial-consoles/g' /boot/efi/EFI/qubes/xen.cfg
+    fi
+fi
+
 /bin/kernel-install add %{kernelrelease} /boot/vmlinuz-%{kernelrelease} || exit $?
 
 # Generate legacy boot grub config


### PR DESCRIPTION
Fixes issue raised in https://github.com/QubesOS/qubes-issues/issues/4902#issuecomment-565758665

Remove xen.cfg modification code.
Clone grub-legacy configuration update code and modify to update EFI configuration
Remove comment stating that grub does not support xen in efi mode.

Change will also have to be backported to stable-4.19

This should not be merged until the following two PRs are merged:
https://github.com/QubesOS/qubes-lorax-templates/pull/1
https://github.com/QubesOS/qubes-anaconda/pull/3
Otherwise it will break any EFI install not using grub. Alternatively, the first deletion (lines 517-522) could be retained to support both configurations.