### PR TITLE
update WireGuard from 20191212 to 20191219

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ HASH_FILE := $(SRC_FILE).sha512
 endif
 
 WG_BASE_URL := https://git.zx2c4.com/WireGuard/snapshot
-WG_SRC_FILE := WireGuard-0.0.20191212.tar.xz
+WG_SRC_FILE := WireGuard-0.0.20191219.tar.xz
 
 WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -113,7 +113,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 %else
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
-Source5:	WireGuard-0.0.20191212.tar.xz
+Source5:	WireGuard-0.0.20191219.tar.xz
 Source16:       guards
 Source17:       apply-patches
 Source18:       mod-sign.sh


### PR DESCRIPTION
update WireGuard from 20191212 to 20191219
(no, i dont know why they suddenly update the snaps this frequently...)

and the usual crosslink ... https://github.com/QubesOS/qubes-issues/issues/5437