### PR TITLE
update WireGuard from 20191219 to 20200105 and new url/file patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ SRC_FILE := linux-${VERSION}.tar.gz
 HASH_FILE := $(SRC_FILE).sha512
 endif
 
-WG_BASE_URL := https://git.zx2c4.com/WireGuard/snapshot
-WG_SRC_FILE := WireGuard-0.0.20191219.tar.xz
+WG_BASE_URL := https://git.zx2c4.com/wireguard-linux-compat/snapshot
+WG_SRC_FILE := wireguard-linux-compat-0.0.20200105.tar.xz
 
 WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -113,7 +113,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 %else
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
-Source5:	WireGuard-0.0.20191219.tar.xz
+Source5:	wireguard-linux-compat-0.0.20200105.tar.xz
 Source16:       guards
 Source17:       apply-patches
 Source18:       mod-sign.sh


### PR DESCRIPTION
and the usual crosslink ... QubesOS/qubes-issues#5437