### PR TITLE
add roadrunner2/macbook12-spi-driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ WireGuard-*.tar.xz
 WireGuard-*.tar.asc
 kernel-*/
 config-base-*
+macbook12-spi-driver-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)
 WG_SIG_URL := $(WG_BASE_URL)/$(WG_SIG_FILE)
 
+SPI_BASE_URL := https://github.com/roadrunner2/macbook12-spi-driver/archive
+SPI_REVISION := 31cc060adcb431efdf9cf547d600bb45bb00a7f4
+SPI_SRC_URL := $(SPI_BASE_URL)/$(SPI_REVISION).tar.gz
+SPI_SRC_FILE := macbook12-spi-driver-$(SPI_REVISION).tar.gz
+SPI_HASH_SHA256 := 46da514227bb2694e571ec4fff746d1302f41cdea5fe7cb2e522349f96ac83c1
+
 URL := $(SRC_BASEURL)/$(SRC_FILE)
 URL_SIGN := $(SRC_BASEURL)/$(SIGN_FILE)
 
@@ -65,7 +71,7 @@ ifeq ($(DOWNLOAD_FROM_GIT),1)
 URL := https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/snapshot/linux-$(VERSION).tar.gz
 endif
 
-get-sources: $(SRC_FILE) $(SIGN_FILE) $(WG_SRC_FILE) $(WG_SIG_FILE)
+get-sources: $(SRC_FILE) $(SIGN_FILE) $(WG_SRC_FILE) $(WG_SIG_FILE) $(SPI_SRC_FILE)
 
 $(SRC_FILE):
 	@wget -q -N $(URL)
@@ -78,6 +84,9 @@ $(WG_SRC_FILE):
 
 $(WG_SIG_FILE):
 	@wget -q -N $(WG_SIG_URL)
+
+$(SPI_SRC_FILE):
+	@wget -q -N -O $(SPI_SRC_FILE) $(SPI_SRC_URL)
 
 import-keys:
 	@if [ -n "$$GNUPGHOME" ]; then rm -f "$$GNUPGHOME/linux-kernel-trustedkeys.gpg"; fi
@@ -94,6 +103,7 @@ else
 	# verify locally based on a signed git tag and commit hash file
 	sha512sum --quiet -c $(HASH_FILE)
 endif
+	@gunzip -c $(SPI_SRC_FILE) | sha256sum | head -c64 | grep -q "^$(SPI_HASH_SHA256)$$"
 
 .PHONY: clean-sources
 clean-sources:
@@ -102,6 +112,9 @@ ifneq ($(SRC_FILE), None)
 endif
 ifneq ($(WG_SRC_FILE), None)
 	-rm $(WG_SRC_FILE) $(WG_SIG_FILE)
+endif
+ifneq ($(SPI_SRC_FILE), None)
+	-rm $(SPI_SRC_FILE)
 endif
 
 

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -114,6 +114,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
 Source5:	wireguard-linux-compat-0.0.20200121.tar.xz
+Source6:        macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4.tar.gz
 Source16:       guards
 Source17:       apply-patches
 Source18:       mod-sign.sh
@@ -212,6 +213,9 @@ rm -rf %_builddir/wireguard
 tar x -C %_builddir -Jpf %{SOURCE5}
 mv %_builddir/$(basename %{SOURCE5} .tar.xz) %_builddir/wireguard
 
+rm -rf %_builddir/macbook12-spi-driver
+tar -x -C %_builddir -zf %{SOURCE6}
+mv %_builddir/$(basename %{SOURCE6} .tar.gz) %_builddir/macbook12-spi-driver
 
 %build
 
@@ -228,6 +232,10 @@ if [ -d "%_builddir/wireguard" ]; then
     make -C %kernel_build_dir M=%_builddir/wireguard/src modules
 fi
 
+# Build applespi, apple-ibridge, apple-ib-tb, apple-ib-als modules
+if [ -d "%_builddir/macbook12-spi-driver" ]; then
+    make -C %kernel_build_dir M=%_builddir/macbook12-spi-driver modules
+fi
 
 %define __modsign_install_post \
   if [ "%{signmodules}" -eq "1" ]; then \
@@ -287,6 +295,9 @@ if [ -d "%_builddir/u2mfn" ]; then
 fi
 if [ -d "%_builddir/wireguard" ]; then
     make modules_install $MAKE_ARGS INSTALL_MOD_PATH=%buildroot M=%_builddir/wireguard/src
+fi
+if [ -d "%_builddir/macbook12-spi-driver" ]; then
+    make modules_install $MAKE_ARGS INSTALL_MOD_PATH=%buildroot M=%_builddir/macbook12-spi-driver
 fi
 
 mkdir -p %buildroot/%src_install_dir


### PR DESCRIPTION
Have tested this on my ``MacBookPro14,3`` (mid-2017), everything worked like a charm.

What's not working (neither with the Linux upstream applespi drivers in linux-5.3, linux-5.4) are some key combinations, such as:

- Ctrl+Alt+F1..12 in X11, console probably as well.. but Alt+Left/Right is a wokaround;
- Ctrl-X, F10 keys in Grub2, this is a known issue: [read 1](https://github.com/Dunedan/mbp-2016-linux/issues/54#issuecomment-370217326), [read 2](https://lists.gnu.org/archive/html/grub-devel/2017-03/msg00012.html) ; This forces me to write ``multiboot2 .., module2 ..., module2 ..., boot`` manually in order to add ``module_blacklist=xen_pciback`` parameter to the end of ``/vmlinuz`` so the system won't freeze during ``qubes-vm@sys-net`` installation/start-up, and only then I can ``qvm-pci detach sys-net dom0:03_00.0`` (where ``03:00.0`` is the ``Broadcom Limited BCM43602 802.11ac Wireless LAN SoC (rev 02)`` wifi adapter); Probably there could be a better way around using ``qubesctl`` states in order to install ``sys-net`` without checking ``Create default system qubes (sys-net, sys-firewall, default DispVM)`` at the first install. Maybe we should come with an additional PR which would not attempt adding a known-buggy wifi adapters such as this.

And these two issues:
- the ``Fn`` key stops working in dom0, domU as soon as I attach the USB controller to a domU (typically sys-usb or sys-net); By "the ``Fn`` key stops working, I mean that the touch bar display (connected over a USB interface under the hood) won't toggle between special (brightness, volume, ...) keys and function-keys (F1..12).
- For the touchbar (don't mix with the touchpad) to work, one needs to run the following commands or follow this procedure if wish doing this manually https://www.qubes-os.org/doc/usb-qubes/#enable-a-usb-keyboard-for-login
  ```
  sudo qubesctl state.sls qvm.usb-keyboard
  ```

----
Child PR: https://github.com/QubesOS/qubes-installer-qubes-os/pull/36
Child PR: https://github.com/QubesOS/qubes-core-admin-linux/pull/57
Related issue: https://github.com/QubesOS/qubes-issues/issues/3784