### PR TITLE
Disable GCC plugins for external modules in autoconf.h too

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -320,11 +320,6 @@ rm -rf %buildroot/lib/modules/%kernelrelease/build/Documentation
 rm -rf %buildroot/lib/modules/%kernelrelease/build/scripts/tracing
 rm -f %buildroot/lib/modules/%kernelrelease/build/scripts/spdxcheck.py
 
-# disable GCC plugins for external modules build, to not fail if different gcc
-# version is used
-sed -e 's/^\(CONFIG_GCC_PLUGIN.*\)=y/# \1 is not set/' .config > \
-        %buildroot/lib/modules/%kernelrelease/build/.config
-
 rm -f %buildroot/lib/modules/%kernelrelease/build/scripts/*.o
 rm -f %buildroot/lib/modules/%kernelrelease/build/scripts/*/*.o
 
@@ -345,6 +340,13 @@ if [ -f tools/objtool/objtool ]; then
     popd
 fi
 
+# disable GCC plugins for external modules build, to not fail if different gcc
+# version is used
+sed -e 's/^\(CONFIG_GCC_PLUGIN.*\)=y/# \1 is not set/' .config > \
+        %buildroot/lib/modules/%kernelrelease/build/.config
+sed -e '/^#define CONFIG_GCC_PLUGIN/d' include/generated/autoconf.h > \
+        %buildroot/lib/modules/%kernelrelease/build/include/generated/autoconf.h
+
 # Copy .config to include/config/auto.conf so "make prepare" is unnecessary.
 cp %buildroot/lib/modules/%kernelrelease/build/.config %buildroot/lib/modules/%kernelrelease/build/include/config/auto.conf
 
@@ -352,6 +354,7 @@ cp %buildroot/lib/modules/%kernelrelease/build/.config %buildroot/lib/modules/%k
 # external modules can be built
 touch -r %buildroot/lib/modules/%kernelrelease/build/Makefile %buildroot/lib/modules/%kernelrelease/build/include/generated/uapi/linux/version.h
 touch -r %buildroot/lib/modules/%kernelrelease/build/.config %buildroot/lib/modules/%kernelrelease/build/include/config/auto.conf
+touch -r %buildroot/lib/modules/%kernelrelease/build/.config %buildroot/lib/modules/%kernelrelease/build/include/generated/autoconf.h
 
 if test -s vmlinux.id; then
 cp vmlinux.id %buildroot/lib/modules/%kernelrelease/build/vmlinux.id


### PR DESCRIPTION
And also move config related commands into one place.

Fixes QubesOS/qubes-issues#2844