### PR TITLE
bump roadrunner2/macbook12-spi-driver driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)
 WG_SIG_URL := $(WG_BASE_URL)/$(WG_SIG_FILE)
 
 SPI_BASE_URL := https://github.com/roadrunner2/macbook12-spi-driver/archive
-SPI_REVISION := 31cc060adcb431efdf9cf547d600bb45bb00a7f4
+SPI_REVISION := ddfbc7733542b8474a0e8f593aba91e06542be4f
 SPI_SRC_URL := $(SPI_BASE_URL)/$(SPI_REVISION).tar.gz
 SPI_SRC_FILE := macbook12-spi-driver-$(SPI_REVISION).tar.gz
-SPI_HASH_SHA256 := 46da514227bb2694e571ec4fff746d1302f41cdea5fe7cb2e522349f96ac83c1
+SPI_HASH_SHA256 := 8039f103fbb351ecbbaddd540feeb7b0b1abfa216f0689a611e43d997426470e
 
 URL := $(SRC_BASEURL)/$(SRC_FILE)
 URL_SIGN := $(SRC_BASEURL)/$(SIGN_FILE)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -114,7 +114,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
 Source5:	wireguard-linux-compat-0.0.20200121.tar.xz
-Source6:        macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4.tar.gz
+Source6:        macbook12-spi-driver-ddfbc7733542b8474a0e8f593aba91e06542be4f.tar.gz
 Source16:       guards
 Source17:       apply-patches
 Source18:       mod-sign.sh


### PR DESCRIPTION
This fixes the following issues with the applespi driver:

```
Feb 23 16:54:56 dom0 kernel: applespi spi-APP000D:00: Received corrupted packet (crc mismatch)
Feb 23 17:04:49 dom0 kernel: applespi spi-APP000D:00: Received corrupted packet (invalid packet length 2198)
Feb 23 17:09:08 dom0 kernel: applespi spi-APP000D:00: Timed out waiting for device info
Feb 23 17:12:49 dom0 kernel: applespi spi-APP000D:00: Received corrupted packet (invalid message length 8 - num-fingers 0, tp-len 48)
```

### References

https://github.com/roadrunner2/macbook12-spi-driver/issues/40
https://github.com/QubesOS/qubes-linux-kernel/pull/161#issuecomment-579225252
https://github.com/QubesOS/qubes-issues/issues/3784

### Difference between the current (31cc060) and the new driver (ddfbc77)

```
[user@build z]$ wget -c https://github.com/roadrunner2/macbook12-spi-driver/archive/31cc060adcb431efdf9cf547d600bb45bb00a7f4.tar.gz
[user@build z]$ wget -c https://github.com/roadrunner2/macbook12-spi-driver/archive/ddfbc7733542b8474a0e8f593aba91e06542be4f.tar.gz

[user@build z]$ sha256sum *.tar
46da514227bb2694e571ec4fff746d1302f41cdea5fe7cb2e522349f96ac83c1  31cc060adcb431efdf9cf547d600bb45bb00a7f4.tar
8039f103fbb351ecbbaddd540feeb7b0b1abfa216f0689a611e43d997426470e  ddfbc7733542b8474a0e8f593aba91e06542be4f.tar

[user@build z]$ diff -Nur macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4 macbook12-spi-driver-ddfbc7733542b8474a0e8f593aba91e06542be4f
diff -Nur macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4/applespi.c macbook12-spi-driver-ddfbc7733542b8474a0e8f593aba91e06542be4f/applespi.c
--- macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4/applespi.c	2020-01-22 11:14:35.000000000 +0100
+++ macbook12-spi-driver-ddfbc7733542b8474a0e8f593aba91e06542be4f/applespi.c	2020-02-24 08:59:53.000000000 +0100
@@ -55,6 +55,8 @@
 #include <linux/platform_device.h>
 #include <linux/spinlock.h>
 #include <linux/spi/spi.h>
+#include <linux/string.h>
+#include <linux/trace_events.h>
 #include <linux/version.h>
 #include <linux/wait.h>
 
@@ -132,6 +134,10 @@
 		    sizeof(touchpad_dimensions), 0444);
 MODULE_PARM_DESC(touchpad_dimensions, "The pixel dimensions of the touchpad, as XxY+W+H .");
 
+static char* trace_event;
+module_param(trace_event, charp, 0444);
+MODULE_PARM_DESC(trace_event, "Enable early event tracing. It takes the form of a comma-separated list of events to enable.");
+
 /**
  * struct keyboard_protocol - keyboard message.
  * message.type = 0x0110, message.length = 0x000a
@@ -639,14 +645,20 @@
 {
 	struct applespi_complete_info *info = context;
 	struct applespi_data *applespi = info->applespi;
+	void (*complete)(void *);
 	unsigned long flags;
 
-	info->complete(applespi);
-
 	spin_lock_irqsave(&applespi->cmd_msg_lock, flags);
 
+	complete = info->complete;
 	info->complete = NULL;
 
+	spin_unlock_irqrestore(&applespi->cmd_msg_lock, flags);
+
+	complete(applespi);
+
+	spin_lock_irqsave(&applespi->cmd_msg_lock, flags);
+
 	if (applespi->cancel_spi && !applespi_async_outstanding(applespi))
 		wake_up_all(&applespi->drain_complete);
 
@@ -938,6 +950,8 @@
 					 applespi->tx_status,
 					 APPLESPI_STATUS_SIZE);
 
+	udelay(SPI_RW_CHG_DELAY_US);
+
 	if (!applespi_check_write_status(applespi, applespi->wr_m.status)) {
 		/*
 		 * If we got an error, we presumably won't get the expected
@@ -1820,6 +1834,30 @@
 			 "Error saving backlight level to EFI vars: %d\n", sts);
 }
 
+static void applespi_enable_early_event_tracing(struct device *dev)
+{
+	char *buf, *event;
+	int sts;
+
+	if (trace_event && trace_event[0]) {
+		buf = kstrdup(trace_event, GFP_KERNEL);
+		if (!buf)
+			return;
+
+		while ((event = strsep(&buf, ","))) {
+			if (event[0]) {
+				sts = trace_set_clr_event("applespi", event, 1);
+				if (sts)
+					dev_warn(dev,
+						 "Error setting trace event '%s': %d\n",
+						 event, sts);
+			}
+		}
+
+		kfree(buf);
+	}
+}
+
 static int applespi_probe(struct spi_device *spi)
 {
 	struct applespi_data *applespi;
@@ -1829,6 +1867,8 @@
 	int sts, i;
 	unsigned long long gpe, usb_status;
 
+	applespi_enable_early_event_tracing(&spi->dev);
+
 	/* check if the USB interface is present and enabled already */
 	acpi_sts = acpi_evaluate_integer(spi_handle, "UIST", NULL, &usb_status);
 	if (ACPI_SUCCESS(acpi_sts) && usb_status) {
[user@build z]$ 
```