### PR TITLE
update WireGuard from 20200121 to 20200215

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ HASH_FILE := $(SRC_FILE).sha512
 endif
 
 WG_BASE_URL := https://git.zx2c4.com/wireguard-linux-compat/snapshot
-WG_SRC_FILE := wireguard-linux-compat-0.0.20200121.tar.xz
+WG_SRC_FILE := wireguard-linux-compat-0.0.20200215.tar.xz
 
 WG_SRC_URL := $(WG_BASE_URL)/$(WG_SRC_FILE)
 WG_SIG_FILE := $(WG_SRC_FILE:%.xz=%.asc)

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -113,7 +113,7 @@ Source0:        linux-%{upstream_version}.tar.xz
 %else
 Source0:        linux-%{upstream_version}.tar.gz
 %endif
-Source5:	wireguard-linux-compat-0.0.20200121.tar.xz
+Source5:	wireguard-linux-compat-0.0.20200215.tar.xz
 Source6:        macbook12-spi-driver-31cc060adcb431efdf9cf547d600bb45bb00a7f4.tar.gz
 Source16:       guards
 Source17:       apply-patches


### PR DESCRIPTION
build and basic functional testing ok. 

... and the usual crosslink https://github.com/QubesOS/qubes-issues/issues/5437

this may be the last WG update we have to do qubes-side.