### PR TITLE
Add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+include:
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.1/gitlab-base.yml'
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.1/gitlab-dom0.yml'
+
+default:
+  tags:
+    - docker-runner
+    - long-living-job


### PR DESCRIPTION
Working case: https://gitlab.com/QubesOS/qubes-linux-kernel/-/pipelines/216342098

To propagate to stable-5.4 and to change dom0 and release for stable-4.19 and 4.14.