### PR TITLE
gitlab-ci: 4.14 package isn't mock-compatible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,9 @@
 include:
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-base.yml'
+    file: '/r4.0/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-dom0.yml'
+    file: '/r4.0/gitlab-dom0.yml'
 
 default:
   tags:
-    - docker-runner
-    - long-living-job
+    - docker


### PR DESCRIPTION
And also update tags