### PR TITLE
Always include u2mfn module, also for R4.1 builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "dummy-backlight"]
 	path = dummy-backlight
 	url = https://github.com/QubesOS/qubes-dummy-backlight
+[submodule "linux-utils"]
+	path = linux-utils
+	url = https://github.com/QubesOS/qubes-linux-utils.git
+	branch = release4.0

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -2,7 +2,7 @@ ifeq ($(PACKAGE_SET),dom0)
 RPM_SPEC_FILES := kernel.spec
 NO_ARCHIVE := 1
 
-INCLUDED_SOURCES = dummy-psu dummy-backlight
+INCLUDED_SOURCES = dummy-psu dummy-backlight linux-utils
 SOURCE_COPY_IN := $(INCLUDED_SOURCES)
 
 $(INCLUDED_SOURCES): PACKAGE=$@

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -111,6 +111,7 @@ Source0:        linux-%{upstream_version}.tar.gz
 %endif
 Source1:        @dummy-psu@
 Source2:        @dummy-backlight@
+Source3:        @linux-utils@
 #Source6:        macbook12-spi-driver-ddfbc7733542b8474a0e8f593aba91e06542be4f.tar.gz
 Source16:       guards
 Source17:       apply-patches
@@ -210,10 +211,7 @@ rm -rf %_builddir/dummy-backlight
 tar -x -C %_builddir -zf %{SOURCE2}
 
 rm -rf %_builddir/u2mfn
-u2mfn_ver=`dkms status u2mfn|tail -n 1|cut -f 2 -d ' '|tr -d ':,:'`
-if [ -n "$u2mfn_ver" ]; then
-    cp -r /usr/src/u2mfn-$u2mfn_ver %_builddir/u2mfn
-fi
+tar -x -C %_builddir -zf %{SOURCE3} --strip-components=2 linux-utils/kernel-modules/u2mfn
 
 #rm -rf %_builddir/macbook12-spi-driver
 #tar -x -C %_builddir -zf %{SOURCE6}


### PR DESCRIPTION
While R4.1 nominally doesn't use u2mfn anymore, VM imported from R4.0
does (in case of dom0-provided kernel, which is the default).

QubesOS/qubes-issues#4867