### PR TITLE
updates: allow pass DNF options from env

### DIFF
--- a/get-fedora-latest-config
+++ b/get-fedora-latest-config
@@ -96,7 +96,7 @@ repo_opts="$repo_opts --enablerepo=updates-testing"
 fi
 
 # shellcheck disable=SC2086
-latestver=$(dnf -q repoquery kernel-core $repo_opts)
+latestver=$(dnf $dnf_opts -q repoquery kernel-core $repo_opts)
 
 # include rc
 if [ "$krc" != "1" ]; then
@@ -117,7 +117,7 @@ if [ "x$latestrpm" != "x" ] && [ "x$releasever" != "x" ]; then
     tmpdir="$(mktemp -d -p "$localdir")"
     # download latest kernel rpm
     # shellcheck disable=SC2086
-    dnf -q download kernel-core $repo_opts
+    dnf $dnf_opts -q download kernel-core $repo_opts
     mv "$latestrpm" "$tmpdir/$latestrpm.untrusted"
 
     # check signature

--- a/update-sources
+++ b/update-sources
@@ -57,10 +57,10 @@ make get-sources
 
 #FC_LATEST="$(curl -s -L https://dl.fedoraproject.org/pub/fedora/linux/releases | sed -e 's/<[^>]*>//g' | awk '{print $1}' | grep -o "[1-9][0-9]" | tail -1)"
 FC_LATEST="$(git ls-remote --heads https://src.fedoraproject.org/rpms/fedora-release | grep -Po "refs/heads/f[0-9][1-9]*" | sed 's#refs/heads/f##g' | sort -g | tail -1)"
-STABLE_KERNEL="$(dnf -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --releasever="$FC_LATEST" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1)"
+STABLE_KERNEL="$(dnf $dnf_opts -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --releasever="$FC_LATEST" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1)"
 if [ "$BRANCH" == "master" ]; then
-    TESTING_KERNEL="$(dnf -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --enablerepo=updates-testing --releasever="$FC_LATEST" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1)"
-    RAWHIDE_KERNEL="$(dnf -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --releasever=rawhide | grep -v "rc[0-9]*" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1 || true)"
+    TESTING_KERNEL="$(dnf $dnf_opts -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --enablerepo=updates-testing --releasever="$FC_LATEST" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1)"
+    RAWHIDE_KERNEL="$(dnf $dnf_opts -q repoquery kernel --disablerepo=* --enablerepo=fedora --enablerepo=updates --releasever=rawhide | grep -v "rc[0-9]*" | sort -V | tail -1 | cut -d ':' -f2 | cut -d '-' -f1 || true)"
 fi
 
 if [ "$BRANCH" == "master" ] && { distance_version "$TESTING_KERNEL" "$LATEST_KERNEL_VERSION"; }; then


### PR DESCRIPTION
To backport to `stable-{5.10,5.4,4.19}` branches for the automatic updater.