### PR TITLE
Enable Xen grant tables to be turned into DMA-BUFs

### DIFF
--- a/config-qubes
+++ b/config-qubes
@@ -131,6 +131,11 @@ CONFIG_XEN_BALLOON_MEMORY_HOTPLUG=y
 CONFIG_XEN_UNPOPULATED_ALLOC=y
 
 ################################################################################
+## Allow grant tables to be turned into dma-bufs and back. Needed by GUI daemon.
+CONFIG_XEN_GRANT_DMA_ALLOC=y
+CONFIG_XEN_GNTDEV_DMABUF=y
+
+################################################################################
 ## Help crash debugging by saving crash messages to EFI variables
 
 CONFIG_EFI_VARS_PSTORE=y


### PR DESCRIPTION
This is needed by the GUI daemon.

Fixes QubesOS/qubes-issues#6743.