### PR TITLE
Fix module loading for 5.13.x with a non-merged /sbin and /usr/sbin

### DIFF
--- a/config-qubes
+++ b/config-qubes
@@ -140,6 +140,12 @@ CONFIG_XEN_GNTDEV_DMABUF=y
 
 CONFIG_EFI_VARS_PSTORE=y
 
+
+################################################################################
+## Support Linux installs where /sbin/ and /usr/sbin/ have not been merged
+
+CONFIG_MODPROBE_PATH="/sbin/modprobe"
+
 ################################################################################
 ## TODO: from diff to old config
 


### PR DESCRIPTION
When updating to 5.13.6, 7fc3b8b1f94caa6d, CONFIG_MODPROBE_PATH was
changed from /sbin/modprobe (default in vanilla kernel) to
/usr/sbin/modprobe. Modern Linux distributions have been linking
/sbin to /usr/sbin, essentially merging the directories, for some
time. On such systems /usr/sbin/modprobe becomes the canonical location.
However, at least on Debian, merging is only done when the usrmerge [1]
package is installed manually on update (or when doing a fresh install).
Thus, there are still systems out there where /usr/sbin/modprobe does not
exist. In order to ensure those systems keep running the path is
changed back to /sbin/modprobe. Systems where /usr/sbin/modprobe
is the canonical location will keep working as there is an symlink
to the right place.

Note that the usrmerge package on Debian cannot be installed as the
script executing the merge cannot handle the overlay FS mounted at
/lib/modules.