### PR TITLE
Fix build on R4.0

### DIFF
--- a/genfs-makefile
+++ b/genfs-makefile
@@ -1,7 +1,6 @@
 MAKEFLAGS ::= -rR
 CFLAGS ::= $(shell pkg-config --cflags --libs ext2fs com_err) \
-    -fstack-protector-all -fcf-protection -fstack-clash-protection -O2 \
-    -D_FORITFY_SOURCE=2 -fwrapv -fwrapv-pointer \
+    -fstack-protector-all -O2 -D_FORITFY_SOURCE=2 -fwrapv \
     -fno-delete-null-pointer-checks -fno-strict-aliasing -Wall -Wextra \
     -Werror=format-security -pedantic-errors -Wformat=2 -Wmaybe-uninitialized \
     -Wshadow -g3


### PR DESCRIPTION
Fedora 25's gcc doesn't support `-fcf-protection`,
`-fstack-clash-protection`, or `-fwrapv-pointer`.  genfs runs on trusted
input, so these flags are not necessary.  Drop them.