### PR TITLE
Fix genfs build on R4.0 (again)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ include:
     file: '/r4.1/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.1/gitlab-dom0.yml'
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.0/gitlab-dom0.yml'
 
 default:
   tags:

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -68,8 +68,10 @@ BuildRequires:  elfutils-libelf-devel
 BuildRequires:  bison
 BuildRequires:  flex
 BuildRequires:  e2fsprogs
+%if 0%{?fedora} >= 32
 # to make the filesystem
 BuildRequires:  e2fsprogs-devel
+%endif
 
 # gcc with support for BTI mitigation
 %if 0%{?fedora} == 25
@@ -215,7 +217,9 @@ mv %_builddir/$(basename %{SOURCE6} .tar) %_builddir/macbook12-spi-driver
 %build
 
 set -e
+%if 0%{?fedora} >= 32
 make -C %{_sourcedir} -f genfs-makefile GENFS=%{_builddir}/genfs
+%endif
 
 cd %kernel_build_dir
 
@@ -506,14 +510,23 @@ cp -a %buildroot/%src_install_dir %buildroot%vm_install_dir/modules/%kernelrelea
 # stubdomain
 cp %buildroot%vm_install_dir/vmlinuz %buildroot%vm_install_dir/modules/
 cp %buildroot%vm_install_dir/initramfs %buildroot%vm_install_dir/modules/
-PATH=/usr/sbin:/sbin:$PATH mkfs.ext3 -F -Enum_backup_sb=0,hash_seed=dcee2318-92bd-47a5-a15d-e79d1412cdce,root_owner=0:0,no_copy_xattrs \
+
+%if 0%{?fedora} >= 32
+flags=,no_copy_xattrs,hash_seed=dcee2318-92bd-47a5-a15d-e79d1412cdce
+%else
+flags=
+%endif
+
+PATH=/usr/sbin:/sbin:$PATH mkfs.ext3 -F "-Enum_backup_sb=0,root_owner=0:0$flags" \
     -d %buildroot%vm_install_dir/modules %buildroot%vm_install_dir/modules.img 512M
 
+%if 0%{?fedora} >= 32
 SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH %{_builddir}/genfs %buildroot%vm_install_dir/modules.img %{VERSION}-%{RELEASE}.%{_arch} immutable=yes
 e2fsck -pDfE optimize_extents -- %buildroot%vm_install_dir/modules.img
 resize2fs -M -- %buildroot%vm_install_dir/modules.img
 e2fsck -pDfE optimize_extents -- %buildroot%vm_install_dir/modules.img
 SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH %{_builddir}/genfs %buildroot%vm_install_dir/modules.img
+%endif
 
 rm -rf %buildroot%vm_install_dir/modules
 


### PR DESCRIPTION
Fedora 25 has an old libext2fs that does not include the `*_hi` time
fields in its definition of `struct ext2_super_block`.  Only use these
fields on Fedora 32 and later.