### PR TITLE
`genfs.c` needs to be compatible with depmod

### DIFF
--- a/genfs.c
+++ b/genfs.c
@@ -345,7 +345,7 @@ static int real_main(const char *const filesystem, const char *const uname) {
             .uname_or_label = uname,
         };
         process_dirent(fs, "", EXT2_ROOT_INO, 0, "",
-                       label_modules_object, mark_immutable);
+                       label_modules_object, false);
         if ((err = ext2fs_dir_iterate2(fs, EXT2_ROOT_INO, 0, NULL,
                                        root_iterate_callback, &data)))
             genfs_err(err, "processing /");

--- a/genfs.c
+++ b/genfs.c
@@ -111,6 +111,7 @@ static int root_iterate_callback(ext2_ino_t dir __attribute__((unused)),
     int const name_len = ext2fs_dirent_name_len(dirent);
     errcode_t err;
     const char *label = label_modules_object;
+    bool mark_this_node_immutable = mark_immutable;
     assert(name_len >= 0);
     if ((name_len == 1 && dirent->name[0] == '.') ||
         (name_len == 2 && dirent->name[0] == '.' && dirent->name[1] == '.')) {
@@ -126,9 +127,11 @@ static int root_iterate_callback(ext2_ino_t dir __attribute__((unused)),
     } else if (!strncmp(dirent->name, data->uname_or_label, (size_t)name_len)) {
         if ((err = ext2fs_dir_iterate2(data->fs, dirent->inode, 0, NULL, dir_iterate_callback, data)))
             genfs_err(err, "processing %s", data->uname_or_label);
+        mark_this_node_immutable = false;
     }
+
     process_dirent(data->fs, "", dirent->inode, name_len, dirent->name,
-                   label, mark_immutable);
+                   label, mark_this_node_immutable);
     return 0;
 }
 

--- a/genfs.c
+++ b/genfs.c
@@ -111,7 +111,11 @@ static int root_iterate_callback(ext2_ino_t dir __attribute__((unused)),
     int const name_len = ext2fs_dirent_name_len(dirent);
     errcode_t err;
     const char *label = label_modules_object;
-    if (!strncmp(dirent->name, "firmware", (size_t)name_len)) {
+    assert(name_len >= 0);
+    if ((name_len == 1 && dirent->name[0] == '.') ||
+        (name_len == 2 && dirent->name[0] == '.' && dirent->name[1] == '.')) {
+        return 0;
+    } else if (!strncmp(dirent->name, "firmware", (size_t)name_len)) {
         struct qubes_genfs_data relabel_data = {
             .fs = data->fs,
             .uname_or_label = label = label_lib,


### PR DESCRIPTION
depmod creates temporary files under `/lib/modules/<kernel version>`, so that directory must be writable.  The first commit is a preliminary change.  The second commit is the actual bug fix, and the third commit ensures that junk doesn’t get added to the dom0-provided kernel module directory by accident.

Fixes QubesOS/qubes-issues#7195.