### PR TITLE
Disable build-id links without debug packages

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -42,6 +42,7 @@
 
 %if !%{with_debuginfo}
 %global debug_package %{nil}
+%define _build_id_links none
 %define setup_config --disable CONFIG_DEBUG_INFO
 %else
 %define setup_config --enable CONFIG_DEBUG_INFO --disable CONFIG_DEBUG_INFO_REDUCED


### PR DESCRIPTION
Hi @marmarek,

This pull request resolves kernel package installation failures caused by conflicting symbolic links in `/usr/lib/.build-id/`.
