### PR TITLE
Switch default clocksource to 'tsc'

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -491,6 +491,7 @@ cp -p arch/x86/boot/bzImage %buildroot/%vm_install_dir/vmlinuz
 # default kernel options for this kernel
 def_kernelopts="root=/dev/mapper/dmroot ro nomodeset console=hvc0"
 def_kernelopts="$def_kernelopts rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0"
+def_kernelopts="$def_kernelopts clocksource=tsc"
 if [ -e /usr/lib/dracut/modules.d/90qubes-vm-simple/xen-scrub-pages-supported ]; then
     # set xen_scrub_pages=0 _only_ when included initramfs does support
     # re-enabling it


### PR DESCRIPTION
The 'tsc' clocksource is significantly faster than 'xen', and since
Qubes OS does not support VM migration, it is safe to use.
In synthetic benchmarks, it improves performance over tenfold, but
significant improvements in real world use cases is visible too.

Fixes QubesOS/qubes-issues#7404