### PR TITLE
Backport frame buffer address fixes from 5.17+

### DIFF
--- a/0001-fb-addr-fix-obtain-full-video-frame-buffer-address.patch
+++ b/0001-fb-addr-fix-obtain-full-video-frame-buffer-address.patch
@@ -1,0 +1,57 @@
+From f34c4f2dd2445ab89e5373fff2990fab36578bd3 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Mon, 7 Feb 2022 08:41:03 +0100
+Subject: xen/x86: obtain full video frame buffer address for Dom0 also under
+ EFI
+
+The initial change would not work when Xen was booted from EFI: There is
+an early exit from the case block in that case. Move the necessary code
+ahead of that.
+
+Fixes: 335e4dd67b48 ("xen/x86: obtain upper 32 bits of video frame buffer address for Dom0")
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+
+Link: https://lore.kernel.org/r/2501ce9d-40e5-b49d-b0e5-435544d17d4a@suse.com
+Signed-off-by: Juergen Gross <jgross@suse.com>
+---
+ arch/x86/xen/vga.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/arch/x86/xen/vga.c b/arch/x86/xen/vga.c
+index 31b1e3477cb63..14ea32e734d59 100644
+--- a/arch/x86/xen/vga.c
++++ b/arch/x86/xen/vga.c
+@@ -57,6 +57,14 @@ void __init xen_init_vga(const struct dom0_vga_console_info *info, size_t size)
+ 		screen_info->rsvd_size = info->u.vesa_lfb.rsvd_size;
+ 		screen_info->rsvd_pos = info->u.vesa_lfb.rsvd_pos;
+ 
++		if (size >= offsetof(struct dom0_vga_console_info,
++				     u.vesa_lfb.ext_lfb_base)
++		    + sizeof(info->u.vesa_lfb.ext_lfb_base)
++		    && info->u.vesa_lfb.ext_lfb_base) {
++			screen_info->ext_lfb_base = info->u.vesa_lfb.ext_lfb_base;
++			screen_info->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
++		}
++
+ 		if (info->video_type == XEN_VGATYPE_EFI_LFB) {
+ 			screen_info->orig_video_isVGA = VIDEO_TYPE_EFI;
+ 			break;
+@@ -66,14 +74,6 @@ void __init xen_init_vga(const struct dom0_vga_console_info *info, size_t size)
+ 				     u.vesa_lfb.mode_attrs)
+ 		    + sizeof(info->u.vesa_lfb.mode_attrs))
+ 			screen_info->vesa_attributes = info->u.vesa_lfb.mode_attrs;
+-
+-		if (size >= offsetof(struct dom0_vga_console_info,
+-				     u.vesa_lfb.ext_lfb_base)
+-		    + sizeof(info->u.vesa_lfb.ext_lfb_base)
+-		    && info->u.vesa_lfb.ext_lfb_base) {
+-			screen_info->ext_lfb_base = info->u.vesa_lfb.ext_lfb_base;
+-			screen_info->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
+-		}
+ 		break;
+ 	}
+ }
+-- 
+cgit 
+

--- a/0001-fb-addr-fix-obtain-upper-32-bits.patch
+++ b/0001-fb-addr-fix-obtain-upper-32-bits.patch
@@ -1,0 +1,65 @@
+From 335e4dd67b480c8fa571ea7e71af0d22047fcfb7 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 4 Jan 2022 09:46:06 +0100
+Subject: xen/x86: obtain upper 32 bits of video frame buffer address for Dom0
+
+The hypervisor has been supplying this information for a couple of major
+releases. Make use of it. The need to set a flag in the capabilities
+field also points out that the prior setting of that field from the
+hypervisor interface's gbl_caps one was wrong, so that code gets deleted
+(there's also no equivalent of this in native boot code).
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Boris Ostrovsky <boris.ostrovsky@oracle.com>
+
+Link: https://lore.kernel.org/r/a3df8bf3-d044-b7bb-3383-cd5239d6d4af@suse.com
+Signed-off-by: Juergen Gross <jgross@suse.com>
+---
+ arch/x86/xen/vga.c          | 12 ++++++++----
+ include/xen/interface/xen.h |  3 +++
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/arch/x86/xen/vga.c b/arch/x86/xen/vga.c
+index e336f223f7f47..31b1e3477cb63 100644
+--- a/arch/x86/xen/vga.c
++++ b/arch/x86/xen/vga.c
+@@ -62,14 +62,18 @@ void __init xen_init_vga(const struct dom0_vga_console_info *info, size_t size)
+ 			break;
+ 		}
+ 
+-		if (size >= offsetof(struct dom0_vga_console_info,
+-				     u.vesa_lfb.gbl_caps)
+-		    + sizeof(info->u.vesa_lfb.gbl_caps))
+-			screen_info->capabilities = info->u.vesa_lfb.gbl_caps;
+ 		if (size >= offsetof(struct dom0_vga_console_info,
+ 				     u.vesa_lfb.mode_attrs)
+ 		    + sizeof(info->u.vesa_lfb.mode_attrs))
+ 			screen_info->vesa_attributes = info->u.vesa_lfb.mode_attrs;
++
++		if (size >= offsetof(struct dom0_vga_console_info,
++				     u.vesa_lfb.ext_lfb_base)
++		    + sizeof(info->u.vesa_lfb.ext_lfb_base)
++		    && info->u.vesa_lfb.ext_lfb_base) {
++			screen_info->ext_lfb_base = info->u.vesa_lfb.ext_lfb_base;
++			screen_info->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
++		}
+ 		break;
+ 	}
+ }
+diff --git a/include/xen/interface/xen.h b/include/xen/interface/xen.h
+index 5e9916939268a..0ca23eca2a9cc 100644
+--- a/include/xen/interface/xen.h
++++ b/include/xen/interface/xen.h
+@@ -722,6 +722,9 @@ struct dom0_vga_console_info {
+ 			uint32_t gbl_caps;
+ 			/* Mode attributes (offset 0x0, VESA command 0x4f01). */
+ 			uint16_t mode_attrs;
++			uint16_t pad;
++			/* high 32 bits of lfb_base */
++			uint32_t ext_lfb_base;
+ 		} vesa_lfb;
+ 	} u;
+ };
+-- 
+cgit 
+

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -134,6 +134,8 @@ Patch5: 0006-block-add-no_part_scan-module-parameter.patch
 Patch12: 0013-xen-pcifront-pciback-Update-pciif.h-with-err-and-res.patch
 Patch17: 0001-xen-don-t-hang-when-resuming-PCI-device.patch
 Patch19: increase-reclaim-speed.patch
+Patch21: 0001-fb-addr-fix-obtain-upper-32-bits.patch
+Patch22: 0001-fb-addr-fix-obtain-full-video-frame-buffer-address.patch
 
 %description
 Qubes Dom0 kernel.


### PR DESCRIPTION
As discussed in https://github.com/QubesOS/qubes-issues/issues/5165#issuecomment-1146832258 and later, here's a PR with two upstream patches in question. Submitting this against 5.10 branch as (AFAIU) the one used in the installer, but I can submit for other branches as well, if relevant - please just let me know.

This is my first one for Qubes (and hopefully not the last 😄), I've followed the respective "how to contribute" docs, but would be happy to correct if anything is missing, just let me know.