### PR TITLE
switch INTEL_PMC_CORE from builtin to module

### DIFF
--- a/config-qubes
+++ b/config-qubes
@@ -146,6 +146,13 @@ CONFIG_EFI_VARS_PSTORE=y
 
 CONFIG_MODPROBE_PATH="/sbin/modprobe"
 
+
+################################################################################
+## workaround for running (unsupported) pv vms on qubes 4.1
+## also need to blacklist the module in the vm/template!
+CONFIG_INTEL_PMC_CORE=m
+
+
 ################################################################################
 ## TODO: from diff to old config
 


### PR DESCRIPTION
"fix" for https://github.com/QubesOS/qubes-issues/issues/6052

* not exactly elegant, 
* but allows running on unsupported HW (no iommu, so pv for pci vms) 
* with minimal manual intervention (install kernel-latest, blacklist module) 
* without  impact on supported HW (module autoloading works)
* and without longterm maintenance impact (no custom patch)