### PR TITLE
Do not override include/config/auto.conf with .config

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -387,9 +387,6 @@ sed -e 's/^\(CONFIG_GCC_PLUGIN.*\)=y/# \1 is not set/' .config > \
 sed -e '/^#define CONFIG_GCC_PLUGIN/d' include/generated/autoconf.h > \
         %buildroot/lib/modules/%kernelrelease/build/include/generated/autoconf.h
 
-# Copy .config to include/config/auto.conf so "make prepare" is unnecessary.
-cp %buildroot/lib/modules/%kernelrelease/build/.config %buildroot/lib/modules/%kernelrelease/build/include/config/auto.conf
-
 # Make sure the Makefile and version.h have a matching timestamp so that
 # external modules can be built
 touch -r %buildroot/lib/modules/%kernelrelease/build/Makefile %buildroot/lib/modules/%kernelrelease/build/include/generated/uapi/linux/version.h


### PR DESCRIPTION
They are not exactly the same format. Differences in quoting break
building external modules.

Fixes QubesOS/qubes-issues#7675