### PR TITLE
stable-6.1: Fix wakeup from suspend to idle

### DIFF
--- a/ACPI-s2idle-Log-when-enabling-wakeup-IRQ-fails.patch
+++ b/ACPI-s2idle-Log-when-enabling-wakeup-IRQ-fails.patch
@@ -1,0 +1,51 @@
+From 930cbdf09bc1818f0380f42b262b4a44d40aafbf Mon Sep 17 00:00:00 2001
+:
+: Upstreamed. Included since 6.4.
+:
+From: Simon Gaiser <simon@invisiblethingslab.com>
+Date: Mon, 13 Mar 2023 15:00:47 +0100
+Subject: [PATCH v2] ACPI: s2idle: Log when enabling wakeup IRQ fails
+
+enable_irq_wake() can fail. Previously acpi_s2idle_prepare() silently
+ignored it's return code. Based on [1] we should try to continue even in
+case of an error, so just log a warning for now.
+
+Discovered when trying to go into s2idle under Xen. This leads to a
+system that can't be woken, since xen-pirq currently doesn't support
+setting wakeup IRQs [2]. With this you get at least some helpful log
+message if you have access to console messages.
+
+Link: https://lore.kernel.org/linux-acpi/20230313125344.2893-1-simon@invisiblethingslab.com/ # v1
+Link: https://lore.kernel.org/linux-acpi/CAJZ5v0jahjt58nP6P5+xRdtD_ndYPvq4ecMVz6nfGu9tf5iaUw@mail.gmail.com/ # [1]
+Link: https://lore.kernel.org/xen-devel/20230313134102.3157-1-simon@invisiblethingslab.com/ # [2]
+Signed-off-by: Simon Gaiser <simon@invisiblethingslab.com>
+---
+v2:
+ - Based on feedback switched to only logging a warning instead of
+   returning an error.
+---
+ drivers/acpi/sleep.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/acpi/sleep.c b/drivers/acpi/sleep.c
+index 4ca667251272..6b30dea94fae 100644
+--- a/drivers/acpi/sleep.c
++++ b/drivers/acpi/sleep.c
+@@ -722,7 +722,13 @@ int acpi_s2idle_begin(void)
+ int acpi_s2idle_prepare(void)
+ {
+ 	if (acpi_sci_irq_valid()) {
+-		enable_irq_wake(acpi_sci_irq);
++		int error;
++
++		error = enable_irq_wake(acpi_sci_irq);
++		if (error)
++			pr_warn("Warning: Failed to enable wakeup from IRQ %d: %d\n",
++				acpi_sci_irq,
++				error);
+ 		acpi_ec_set_gpe_wake_mask(ACPI_GPE_ENABLE);
+ 	}
+ 
+-- 
+2.39.2
+

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -146,6 +146,10 @@ Patch30: v3-0003-efi-Apply-allowlist-to-EFI-configuration-tables-w.patch
 Patch31: v3-0004-efi-Actually-enable-the-ESRT-under-Xen.patch
 Patch32: v3-0005-efi-Warn-if-trying-to-reserve-memory-under-Xen.patch
 
+# S0ix support:
+Patch60: ACPI-s2idle-Log-when-enabling-wakeup-IRQ-fails.patch
+Patch61: xen-events-Add-wakeup-support-to-xen-pirq.patch
+
 %description
 Qubes Dom0 kernel.
 

--- a/xen-events-Add-wakeup-support-to-xen-pirq.patch
+++ b/xen-events-Add-wakeup-support-to-xen-pirq.patch
@@ -1,0 +1,47 @@
+From 3a3cbf4f4e6289ecc421ebea610e68e95aaf37ec Mon Sep 17 00:00:00 2001
+:
+: Waiting for upstream review:
+: https://lore.kernel.org/xen-devel/20230313134102.3157-1-simon@invisiblethingslab.com/
+:
+From: Simon Gaiser <simon@invisiblethingslab.com>
+Date: Mon, 13 Mar 2023 14:01:47 +0100
+Subject: [PATCH] xen/events: Add wakeup support to xen-pirq
+
+This allows entering and exiting s2idle. Actual S0ix residency is
+another topic [1].
+
+Without this the ACPI code currently ignores the error enable_irq_wake()
+returns when being used on a xen-pirq and the system goes to idle for
+ever since the wakeup IRQ doesn't gets enabled. With [2] the error is
+handled and the system refuses to go to s2idle.
+
+Link: https://lore.kernel.org/xen-devel/9051e484-b128-715a-9253-48af8e47bb9d@invisiblethingslab.com/ # [1]
+Link: https://lore.kernel.org/linux-acpi/20230313125344.2893-1-simon@invisiblethingslab.com/ # [2]
+Signed-off-by: Simon Gaiser <simon@invisiblethingslab.com>
+---
+
+While I think that the set of flags I set is correct, I'm not familiar
+with that code, so please pay special attention during review if they
+are actually correct for xen-pirq.
+
+ drivers/xen/events/events_base.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/xen/events/events_base.c b/drivers/xen/events/events_base.c
+index c7715f8bd452..991082f04f05 100644
+--- a/drivers/xen/events/events_base.c
++++ b/drivers/xen/events/events_base.c
+@@ -2173,6 +2173,10 @@ static struct irq_chip xen_pirq_chip __read_mostly = {
+ 	.irq_set_affinity	= set_affinity_irq,
+ 
+ 	.irq_retrigger		= retrigger_dynirq,
++
++	.flags                  = IRQCHIP_SKIP_SET_WAKE |
++				  IRQCHIP_ENABLE_WAKEUP_ON_SUSPEND |
++				  IRQCHIP_MASK_ON_SUSPEND,
+ };
+ 
+ static struct irq_chip xen_percpu_chip __read_mostly = {
+-- 
+2.39.2
+


### PR DESCRIPTION
Also add a small patch to improved logging when enabling of the wakeip IRQ fails (already upstream, but not backported).