### PR TITLE
Add experimental flag to use suspend instad of freeze for Xen VM suspend

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -147,6 +147,7 @@ Patch28: 0001-iwlwifi-avoid-writing-to-MSI-X-page-when-MSI-X-is-no.patch
 
 # S0ix support:
 Patch61: xen-events-Add-wakeup-support-to-xen-pirq.patch
+Patch62: xen-pm-use-suspend.patch
 
 %description
 Qubes Dom0 kernel.

--- a/xen-pm-use-suspend.patch
+++ b/xen-pm-use-suspend.patch
@@ -1,0 +1,50 @@
+diff --git a/drivers/xen/manage.c b/drivers/xen/manage.c
+index c16df629907e..e3cf8e021930 100644
+--- a/drivers/xen/manage.c
++++ b/drivers/xen/manage.c
+@@ -46,6 +46,9 @@ struct suspend_info {
+ 
+ static RAW_NOTIFIER_HEAD(xen_resume_notifier);
+ 
++static bool __read_mostly use_suspend;
++module_param_named(qubes_exp_pm_use_suspend, use_suspend, bool, 0);
++
+ void xen_resume_notifier_register(struct notifier_block *nb)
+ {
+ 	raw_notifier_chain_register(&xen_resume_notifier, nb);
+@@ -113,7 +116,7 @@ static void do_suspend(void)
+ 		goto out_thaw;
+ 	}
+ 
+-	err = dpm_suspend_start(PMSG_FREEZE);
++	err = dpm_suspend_start(use_suspend ? PMSG_SUSPEND : PMSG_FREEZE);
+ 	if (err) {
+ 		pr_err("%s: dpm_suspend_start %d\n", __func__, err);
+ 		goto out_thaw;
+@@ -122,7 +125,7 @@ static void do_suspend(void)
+ 	printk(KERN_DEBUG "suspending xenstore...\n");
+ 	xs_suspend();
+ 
+-	err = dpm_suspend_end(PMSG_FREEZE);
++	err = dpm_suspend_end(use_suspend ? PMSG_SUSPEND : PMSG_FREEZE);
+ 	if (err) {
+ 		pr_err("dpm_suspend_end failed: %d\n", err);
+ 		si.cancelled = 0;
+@@ -143,7 +146,7 @@ static void do_suspend(void)
+ 
+ 	xen_arch_resume();
+ 
+-	dpm_resume_start(si.cancelled ? PMSG_THAW : PMSG_RESTORE);
++	dpm_resume_start(use_suspend ? PMSG_RESUME : (si.cancelled ? PMSG_THAW : PMSG_RESTORE));
+ 
+ 	if (err) {
+ 		pr_err("failed to start xen_suspend: %d\n", err);
+@@ -156,7 +159,7 @@ static void do_suspend(void)
+ 	else
+ 		xs_suspend_cancel();
+ 
+-	dpm_resume_end(si.cancelled ? PMSG_THAW : PMSG_RESTORE);
++	dpm_resume_end(use_suspend ? PMSG_RESUME : (si.cancelled ? PMSG_THAW : PMSG_RESTORE));
+ 
+ out_thaw:
+ 	thaw_processes();


### PR DESCRIPTION
When suspending a VM the Xen driver currently uses the "freeze" methods for going to sleep. This doesn't put devices in low power state, at least for some drivers (for example USB). But for S0ix we need to put all (real) devices into their low power state. For this the "suspend" methods needs to be used.

(See Documentation/driver-api/pm/devices.rst for description of those methods.)

To be able to include this in a stable release put this behind an experimental flag such that by default the old behavior is unmodified. This flag is unstable and likely will go away.