### PR TITLE
Switch to py3_shebang_fix

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -191,7 +191,7 @@ sed -i -e 's/^EXTRAVERSION = -rc.*/EXTRAVERSION =/' Makefile
 # This fixes errors such as
 # *** ERROR: ambiguous python shebang in /usr/bin/kvm_stat: #!/usr/bin/python. Change it to python3 (or python2) explicitly.
 # We patch all sources below for which we got a report/error.
-pathfix.py -i "%{__python3} %{py3_shbang_opts}" -p -n \
+%py3_shebang_fix \
 	tools/kvm/kvm_stat/kvm_stat \
 	scripts/show_delta \
 	scripts/diffconfig \


### PR DESCRIPTION
pathfix changed its location between f37 and f40, but helpfully there is
a macro for it.