### PR TITLE
Add xen-blkfront sector_size patch; refresh 'removable' patch

### DIFF
--- a/0004-pvops-respect-removable-xenstore-flag-for-block-devi.patch
+++ b/0004-pvops-respect-removable-xenstore-flag-for-block-devi.patch
@@ -1,4 +1,4 @@
-From c7fcd9707db89f169135298bf0351d4931ee2b1f Mon Sep 17 00:00:00 2001
+From 5be0986f3e697c6b9b1f9d7427984b23d02ca80c Mon Sep 17 00:00:00 2001
 From: Marek Marczykowski <marmarek@invisiblethingslab.com>
 Date: Mon, 11 Jun 2012 22:49:31 +0200
 Subject: [PATCH] pvops: respect 'removable' xenstore flag for block devices
@@ -10,18 +10,18 @@ by normal user.
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/block/xen-blkfront.c b/drivers/block/xen-blkfront.c
-index 3b889ea950c2..59f57e55a36b 100644
+index 67aa63dabcff..d5c0da5fe1cb 100644
 --- a/drivers/block/xen-blkfront.c
 +++ b/drivers/block/xen-blkfront.c
-@@ -2347,6 +2347,7 @@ static void blkfront_connect(struct blkfront_info *info)
- 	unsigned int physical_sector_size;
+@@ -2314,6 +2314,7 @@ static void blkfront_connect(struct blkfront_info *info)
+ 	unsigned long long sectors;
  	int err, i;
  	struct blkfront_ring_info *rinfo;
 +	int removable;
  
  	switch (info->connected) {
  	case BLKIF_STATE_CONNECTED:
-@@ -2411,6 +2412,12 @@ static void blkfront_connect(struct blkfront_info *info)
+@@ -2378,6 +2379,12 @@ static void blkfront_connect(struct blkfront_info *info)
  		}
  	}
  
@@ -31,9 +31,9 @@ index 3b889ea950c2..59f57e55a36b 100644
 +	if (!err && removable)
 +		info->vdisk_info |= VDISK_REMOVABLE;
 +
- 	err = xlvbd_alloc_gendisk(sectors, info, sector_size,
- 				  physical_sector_size);
+ 	err = xlvbd_alloc_gendisk(sectors, info);
  	if (err) {
+ 		xenbus_dev_fatal(info->xbdev, err, "xlvbd_add at %s",
 -- 
-2.25.4
+2.45.2
 

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -136,7 +136,6 @@ Source101:      config-qubes
 
 Patch1: 0002-mce-hide-EBUSY-initialization-error-on-Xen.patch
 Patch2: 0003-Log-error-code-of-EVTCHNOP_bind_pirq-failure.patch
-Patch3: 0004-pvops-respect-removable-xenstore-flag-for-block-devi.patch
 Patch5: 0006-block-add-no_part_scan-module-parameter.patch
 Patch12: 0013-xen-pcifront-pciback-Update-pciif.h-with-err-and-res.patch
 Patch16: 0001-usbip-tweak-clear-halt-with-simple-reset.patch
@@ -144,6 +143,8 @@ Patch25: 0001-Re-enable-interrupts-before-loading-PNVM.patch
 Patch26: 0001-sound-Disable-SG-buffer.patch
 Patch27: 0001-amdgpu-timeout.patch
 Patch28: 0001-iwlwifi-avoid-writing-to-MSI-X-page-when-MSI-X-is-no.patch
+Patch29: xen-blkfront-fix-sector_size-propagation-to-the-block-layer.patch
+Patch30: 0004-pvops-respect-removable-xenstore-flag-for-block-devi.patch
 
 # S0ix support:
 Patch61: xen-events-Add-wakeup-support-to-xen-pirq.patch

--- a/xen-blkfront-fix-sector_size-propagation-to-the-block-layer.patch
+++ b/xen-blkfront-fix-sector_size-propagation-to-the-block-layer.patch
@@ -1,0 +1,83 @@
+From patchwork Tue Jun 25 05:52:38 2024
+From: Christoph Hellwig <hch@lst.de>
+Subject: [PATCH] xen-blkfront: fix sector_size propagation to the block layer
+Date: Tue, 25 Jun 2024 07:52:38 +0200
+
+Ensure that info->sector_size and info->physical_sector_size are set
+before the call to blkif_set_queue_limits by doing away with the
+local variables and arguments that propagate them.
+
+Thanks to Marek Marczykowski-Górecki and Jürgen Groß for root causing
+the issue.
+
+Fixes: ba3f67c11638 ("xen-blkfront: atomically update queue limits")
+Reported-by: Rusty Bird <rustybird@net-c.com>
+Signed-off-by: Christoph Hellwig <hch@lst.de>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ drivers/block/xen-blkfront.c | 16 +++++-----------
+ 1 file changed, 5 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/block/xen-blkfront.c b/drivers/block/xen-blkfront.c
+index fa3a2ba525458b..59ce113b882a0e 100644
+--- a/drivers/block/xen-blkfront.c
++++ b/drivers/block/xen-blkfront.c
+@@ -1070,8 +1070,7 @@ static char *encode_disk_name(char *ptr, unsigned int n)
+ }
+ 
+ static int xlvbd_alloc_gendisk(blkif_sector_t capacity,
+-		struct blkfront_info *info, u16 sector_size,
+-		unsigned int physical_sector_size)
++		struct blkfront_info *info)
+ {
+ 	struct queue_limits lim = {};
+ 	struct gendisk *gd;
+@@ -1165,8 +1164,6 @@ static int xlvbd_alloc_gendisk(blkif_sector_t capacity,
+ 
+ 	info->rq = gd->queue;
+ 	info->gd = gd;
+-	info->sector_size = sector_size;
+-	info->physical_sector_size = physical_sector_size;
+ 
+ 	xlvbd_flush(info);
+ 
+@@ -2320,8 +2317,6 @@ static void blkfront_gather_backend_features(struct blkfront_info *info)
+ static void blkfront_connect(struct blkfront_info *info)
+ {
+ 	unsigned long long sectors;
+-	unsigned long sector_size;
+-	unsigned int physical_sector_size;
+ 	int err, i;
+ 	struct blkfront_ring_info *rinfo;
+ 
+@@ -2360,7 +2355,7 @@ static void blkfront_connect(struct blkfront_info *info)
+ 	err = xenbus_gather(XBT_NIL, info->xbdev->otherend,
+ 			    "sectors", "%llu", &sectors,
+ 			    "info", "%u", &info->vdisk_info,
+-			    "sector-size", "%lu", &sector_size,
++			    "sector-size", "%lu", &info->sector_size,
+ 			    NULL);
+ 	if (err) {
+ 		xenbus_dev_fatal(info->xbdev, err,
+@@ -2374,9 +2369,9 @@ static void blkfront_connect(struct blkfront_info *info)
+ 	 * provide this. Assume physical sector size to be the same as
+ 	 * sector_size in that case.
+ 	 */
+-	physical_sector_size = xenbus_read_unsigned(info->xbdev->otherend,
++	info->physical_sector_size = xenbus_read_unsigned(info->xbdev->otherend,
+ 						    "physical-sector-size",
+-						    sector_size);
++						    info->sector_size);
+ 	blkfront_gather_backend_features(info);
+ 	for_each_rinfo(info, rinfo, i) {
+ 		err = blkfront_setup_indirect(rinfo);
+@@ -2388,8 +2383,7 @@ static void blkfront_connect(struct blkfront_info *info)
+ 		}
+ 	}
+ 
+-	err = xlvbd_alloc_gendisk(sectors, info, sector_size,
+-				  physical_sector_size);
++	err = xlvbd_alloc_gendisk(sectors, info);
+ 	if (err) {
+ 		xenbus_dev_fatal(info->xbdev, err, "xlvbd_add at %s",
+ 				 info->xbdev->otherend);


### PR DESCRIPTION
https://patchwork.kernel.org/project/xen-devel/patch/20240625055238.7934-1-hch@lst.de/

Fixes QubesOS/qubes-issues#9293

---

This is the real (presumably final) patch. Marked as draft while I'm waiting for the build to finish so I can test it too