### PR TITLE
Backport fixes for Intel VMD in Xen dom0

### DIFF
--- a/0001-xen-pci-Do-not-register-devices-with-segments-0x1000.patch
+++ b/0001-xen-pci-Do-not-register-devices-with-segments-0x1000.patch
@@ -1,0 +1,93 @@
+From 7c59ccc33797a0efd29857d17d199cf07550ca74 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 19 Feb 2025 10:20:55 +0100
+Subject: [PATCH 1/3] xen/pci: Do not register devices with segments >= 0x10000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The current hypercall interface for doing PCI device operations always uses
+a segment field that has a 16 bit width.  However on Linux there are buses
+like VMD that hook up devices into the PCI hierarchy at segment >= 0x10000,
+after the maximum possible segment enumerated in ACPI.
+
+Attempting to register or manage those devices with Xen would result in
+errors at best, or overlaps with existing devices living on the truncated
+equivalent segment values.  Note also that the VMD segment numbers are
+arbitrarily assigned by the OS, and hence there would need to be some
+negotiation between Xen and the OS to agree on how to enumerate VMD
+segments and devices behind them.
+
+Skip notifying Xen about those devices.  Given how VMD bridges can
+multiplex interrupts on behalf of devices behind them there's no need for
+Xen to be aware of such devices for them to be usable by Linux.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Juergen Gross <jgross@suse.com>
+Message-ID: <20250219092059.90850-2-roger.pau@citrix.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 5ccf1b8ae76ddf348e02a0d1564ff9baf8b6c415)
+---
+ drivers/xen/pci.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/drivers/xen/pci.c b/drivers/xen/pci.c
+index 416f231809cb..bfe07adb3e3a 100644
+--- a/drivers/xen/pci.c
++++ b/drivers/xen/pci.c
+@@ -43,6 +43,18 @@ static int xen_add_device(struct device *dev)
+ 		pci_mcfg_reserved = true;
+ 	}
+ #endif
++
++	if (pci_domain_nr(pci_dev->bus) >> 16) {
++		/*
++		 * The hypercall interface is limited to 16bit PCI segment
++		 * values, do not attempt to register devices with Xen in
++		 * segments greater or equal than 0x10000.
++		 */
++		dev_info(dev,
++			 "not registering with Xen: invalid PCI segment\n");
++		return 0;
++	}
++
+ 	if (pci_seg_supported) {
+ 		DEFINE_RAW_FLEX(struct physdev_pci_device_add, add, optarr, 1);
+ 
+@@ -149,6 +161,16 @@ static int xen_remove_device(struct device *dev)
+ 	int r;
+ 	struct pci_dev *pci_dev = to_pci_dev(dev);
+ 
++	if (pci_domain_nr(pci_dev->bus) >> 16) {
++		/*
++		 * The hypercall interface is limited to 16bit PCI segment
++		 * values.
++		 */
++		dev_info(dev,
++			 "not unregistering with Xen: invalid PCI segment\n");
++		return 0;
++	}
++
+ 	if (pci_seg_supported) {
+ 		struct physdev_pci_device device = {
+ 			.seg = pci_domain_nr(pci_dev->bus),
+@@ -182,6 +204,16 @@ int xen_reset_device(const struct pci_dev *dev)
+ 		.flags = PCI_DEVICE_RESET_FLR,
+ 	};
+ 
++	if (pci_domain_nr(dev->bus) >> 16) {
++		/*
++		 * The hypercall interface is limited to 16bit PCI segment
++		 * values.
++		 */
++		dev_info(&dev->dev,
++			 "unable to notify Xen of device reset: invalid PCI segment\n");
++		return 0;
++	}
++
+ 	return HYPERVISOR_physdev_op(PHYSDEVOP_pci_device_reset, &device);
+ }
+ EXPORT_SYMBOL_GPL(xen_reset_device);
+-- 
+2.48.1
+

--- a/0002-PCI-vmd-Disable-MSI-remapping-bypass-under-Xen.patch
+++ b/0002-PCI-vmd-Disable-MSI-remapping-bypass-under-Xen.patch
@@ -1,0 +1,74 @@
+From 9066faace6635bf2edcf5903c82bc34147ef191c Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 19 Feb 2025 10:20:56 +0100
+Subject: [PATCH 2/3] PCI: vmd: Disable MSI remapping bypass under Xen
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MSI remapping bypass (directly configuring MSI entries for devices on the
+VMD bus) won't work under Xen, as Xen is not aware of devices in such bus,
+and hence cannot configure the entries using the pIRQ interface in the PV
+case, and in the PVH case traps won't be setup for MSI entries for such
+devices.
+
+Until Xen is aware of devices in the VMD bus prevent the
+VMD_FEAT_CAN_BYPASS_MSI_REMAP capability from being used when running as
+any kind of Xen guest.
+
+The MSI remapping bypass is an optional feature of VMD bridges, and hence
+when running under Xen it will be masked and devices will be forced to
+redirect its interrupts from the VMD bridge.  That mode of operation must
+always be supported by VMD bridges and works when Xen is not aware of
+devices behind the VMD bridge.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Bjorn Helgaas <bhelgaas@google.com>
+Message-ID: <20250219092059.90850-3-roger.pau@citrix.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit 6c4d5aadf5df31ea0ac025980670eee9beaf466b)
+---
+ drivers/pci/controller/vmd.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/drivers/pci/controller/vmd.c b/drivers/pci/controller/vmd.c
+index 9d9596947350..e619accca49d 100644
+--- a/drivers/pci/controller/vmd.c
++++ b/drivers/pci/controller/vmd.c
+@@ -17,6 +17,8 @@
+ #include <linux/rculist.h>
+ #include <linux/rcupdate.h>
+ 
++#include <xen/xen.h>
++
+ #include <asm/irqdomain.h>
+ 
+ #define VMD_CFGBAR	0
+@@ -970,6 +972,24 @@ static int vmd_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 	struct vmd_dev *vmd;
+ 	int err;
+ 
++	if (xen_domain()) {
++		/*
++		 * Xen doesn't have knowledge about devices in the VMD bus
++		 * because the config space of devices behind the VMD bridge is
++		 * not known to Xen, and hence Xen cannot discover or configure
++		 * them in any way.
++		 *
++		 * Bypass of MSI remapping won't work in that case as direct
++		 * write by Linux to the MSI entries won't result in functional
++		 * interrupts, as Xen is the entity that manages the host
++		 * interrupt controller and must configure interrupts.  However
++		 * multiplexing of interrupts by the VMD bridge will work under
++		 * Xen, so force the usage of that mode which must always be
++		 * supported by VMD bridges.
++		 */
++		features &= ~VMD_FEAT_CAN_BYPASS_MSI_REMAP;
++	}
++
+ 	if (resource_size(&dev->resource[VMD_CFGBAR]) < (1 << 20))
+ 		return -ENOMEM;
+ 
+-- 
+2.48.1
+

--- a/0003-PCI-MSI-Convert-pci_msi_ignore_mask-to-per-MSI-domai.patch
+++ b/0003-PCI-MSI-Convert-pci_msi_ignore_mask-to-per-MSI-domai.patch
@@ -1,0 +1,218 @@
+From 925425721030364d176f0579edd638cdd28e0c28 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 19 Feb 2025 10:20:57 +0100
+Subject: [PATCH 3/3] PCI/MSI: Convert pci_msi_ignore_mask to per MSI domain
+ flag
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Setting pci_msi_ignore_mask inhibits the toggling of the mask bit for both
+MSI and MSI-X entries globally, regardless of the IRQ chip they are using.
+Only Xen sets the pci_msi_ignore_mask when routing physical interrupts over
+event channels, to prevent PCI code from attempting to toggle the maskbit,
+as it's Xen that controls the bit.
+
+However, the pci_msi_ignore_mask being global will affect devices that use
+MSI interrupts but are not routing those interrupts over event channels
+(not using the Xen pIRQ chip).  One example is devices behind a VMD PCI
+bridge.  In that scenario the VMD bridge configures MSI(-X) using the
+normal IRQ chip (the pIRQ one in the Xen case), and devices behind the
+bridge configure the MSI entries using indexes into the VMD bridge MSI
+table.  The VMD bridge then demultiplexes such interrupts and delivers to
+the destination device(s).  Having pci_msi_ignore_mask set in that scenario
+prevents (un)masking of MSI entries for devices behind the VMD bridge.
+
+Move the signaling of no entry masking into the MSI domain flags, as that
+allows setting it on a per-domain basis.  Set it for the Xen MSI domain
+that uses the pIRQ chip, while leaving it unset for the rest of the
+cases.
+
+Remove pci_msi_ignore_mask at once, since it was only used by Xen code, and
+with Xen dropping usage the variable is unneeded.
+
+This fixes using devices behind a VMD bridge on Xen PV hardware domains.
+
+Albeit Devices behind a VMD bridge are not known to Xen, that doesn't mean
+Linux cannot use them.  By inhibiting the usage of
+VMD_FEAT_CAN_BYPASS_MSI_REMAP and the removal of the pci_msi_ignore_mask
+bodge devices behind a VMD bridge do work fine when use from a Linux Xen
+hardware domain.  That's the whole point of the series.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Thomas Gleixner <tglx@linutronix.de>
+Acked-by: Juergen Gross <jgross@suse.com>
+Acked-by: Bjorn Helgaas <bhelgaas@google.com>
+Message-ID: <20250219092059.90850-4-roger.pau@citrix.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+(cherry picked from commit c3164d2e0d181027da8fc94f8179d8607c3d440f)
+---
+ arch/x86/pci/xen.c    |  8 ++------
+ drivers/pci/msi/msi.c | 37 +++++++++++++++++++++----------------
+ include/linux/msi.h   |  3 ++-
+ kernel/irq/msi.c      |  2 +-
+ 4 files changed, 26 insertions(+), 24 deletions(-)
+
+diff --git a/arch/x86/pci/xen.c b/arch/x86/pci/xen.c
+index 0f2fe524f60d..b8755cde2419 100644
+--- a/arch/x86/pci/xen.c
++++ b/arch/x86/pci/xen.c
+@@ -436,7 +436,8 @@ static struct msi_domain_ops xen_pci_msi_domain_ops = {
+ };
+ 
+ static struct msi_domain_info xen_pci_msi_domain_info = {
+-	.flags			= MSI_FLAG_PCI_MSIX | MSI_FLAG_FREE_MSI_DESCS | MSI_FLAG_DEV_SYSFS,
++	.flags			= MSI_FLAG_PCI_MSIX | MSI_FLAG_FREE_MSI_DESCS |
++				  MSI_FLAG_DEV_SYSFS | MSI_FLAG_NO_MASK,
+ 	.ops			= &xen_pci_msi_domain_ops,
+ };
+ 
+@@ -484,11 +485,6 @@ static __init void xen_setup_pci_msi(void)
+ 	 * in allocating the native domain and never use it.
+ 	 */
+ 	x86_init.irqs.create_pci_msi_domain = xen_create_pci_msi_domain;
+-	/*
+-	 * With XEN PIRQ/Eventchannels in use PCI/MSI[-X] masking is solely
+-	 * controlled by the hypervisor.
+-	 */
+-	pci_msi_ignore_mask = 1;
+ }
+ 
+ #else /* CONFIG_PCI_MSI */
+diff --git a/drivers/pci/msi/msi.c b/drivers/pci/msi/msi.c
+index 2f647cac4cae..4c8c2b57b5f6 100644
+--- a/drivers/pci/msi/msi.c
++++ b/drivers/pci/msi/msi.c
+@@ -10,12 +10,12 @@
+ #include <linux/err.h>
+ #include <linux/export.h>
+ #include <linux/irq.h>
++#include <linux/irqdomain.h>
+ 
+ #include "../pci.h"
+ #include "msi.h"
+ 
+ int pci_msi_enable = 1;
+-int pci_msi_ignore_mask;
+ 
+ /**
+  * pci_msi_supported - check whether MSI may be enabled on a device
+@@ -285,6 +285,8 @@ static void pci_msi_set_enable(struct pci_dev *dev, int enable)
+ static int msi_setup_msi_desc(struct pci_dev *dev, int nvec,
+ 			      struct irq_affinity_desc *masks)
+ {
++	const struct irq_domain *d = dev_get_msi_domain(&dev->dev);
++	const struct msi_domain_info *info = d->host_data;
+ 	struct msi_desc desc;
+ 	u16 control;
+ 
+@@ -295,8 +297,7 @@ static int msi_setup_msi_desc(struct pci_dev *dev, int nvec,
+ 	/* Lies, damned lies, and MSIs */
+ 	if (dev->dev_flags & PCI_DEV_FLAGS_HAS_MSI_MASKING)
+ 		control |= PCI_MSI_FLAGS_MASKBIT;
+-	/* Respect XEN's mask disabling */
+-	if (pci_msi_ignore_mask)
++	if (info->flags & MSI_FLAG_NO_MASK)
+ 		control &= ~PCI_MSI_FLAGS_MASKBIT;
+ 
+ 	desc.nvec_used			= nvec;
+@@ -604,12 +605,15 @@ static void __iomem *msix_map_region(struct pci_dev *dev,
+  */
+ void msix_prepare_msi_desc(struct pci_dev *dev, struct msi_desc *desc)
+ {
++	const struct irq_domain *d = dev_get_msi_domain(&dev->dev);
++	const struct msi_domain_info *info = d->host_data;
++
+ 	desc->nvec_used				= 1;
+ 	desc->pci.msi_attrib.is_msix		= 1;
+ 	desc->pci.msi_attrib.is_64		= 1;
+ 	desc->pci.msi_attrib.default_irq	= dev->irq;
+ 	desc->pci.mask_base			= dev->msix_base;
+-	desc->pci.msi_attrib.can_mask		= !pci_msi_ignore_mask &&
++	desc->pci.msi_attrib.can_mask		= !(info->flags & MSI_FLAG_NO_MASK) &&
+ 						  !desc->pci.msi_attrib.is_virtual;
+ 
+ 	if (desc->pci.msi_attrib.can_mask) {
+@@ -659,9 +663,6 @@ static void msix_mask_all(void __iomem *base, int tsize)
+ 	u32 ctrl = PCI_MSIX_ENTRY_CTRL_MASKBIT;
+ 	int i;
+ 
+-	if (pci_msi_ignore_mask)
+-		return;
+-
+ 	for (i = 0; i < tsize; i++, base += PCI_MSIX_ENTRY_SIZE)
+ 		writel(ctrl, base + PCI_MSIX_ENTRY_VECTOR_CTRL);
+ }
+@@ -714,6 +715,8 @@ static int msix_setup_interrupts(struct pci_dev *dev, struct msix_entry *entries
+ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 				int nvec, struct irq_affinity *affd)
+ {
++	const struct irq_domain *d = dev_get_msi_domain(&dev->dev);
++	const struct msi_domain_info *info = d->host_data;
+ 	int ret, tsize;
+ 	u16 control;
+ 
+@@ -744,15 +747,17 @@ static int msix_capability_init(struct pci_dev *dev, struct msix_entry *entries,
+ 	/* Disable INTX */
+ 	pci_intx_for_msi(dev, 0);
+ 
+-	/*
+-	 * Ensure that all table entries are masked to prevent
+-	 * stale entries from firing in a crash kernel.
+-	 *
+-	 * Done late to deal with a broken Marvell NVME device
+-	 * which takes the MSI-X mask bits into account even
+-	 * when MSI-X is disabled, which prevents MSI delivery.
+-	 */
+-	msix_mask_all(dev->msix_base, tsize);
++	if (!(info->flags & MSI_FLAG_NO_MASK)) {
++		/*
++		 * Ensure that all table entries are masked to prevent
++		 * stale entries from firing in a crash kernel.
++		 *
++		 * Done late to deal with a broken Marvell NVME device
++		 * which takes the MSI-X mask bits into account even
++		 * when MSI-X is disabled, which prevents MSI delivery.
++		 */
++		msix_mask_all(dev->msix_base, tsize);
++	}
+ 	pci_msix_clear_and_set_ctrl(dev, PCI_MSIX_FLAGS_MASKALL, 0);
+ 
+ 	pcibios_free_irq(dev);
+diff --git a/include/linux/msi.h b/include/linux/msi.h
+index b10093c4d00e..59a421fc42bf 100644
+--- a/include/linux/msi.h
++++ b/include/linux/msi.h
+@@ -73,7 +73,6 @@ struct msi_msg {
+ 	};
+ };
+ 
+-extern int pci_msi_ignore_mask;
+ /* Helper functions */
+ struct msi_desc;
+ struct pci_dev;
+@@ -556,6 +555,8 @@ enum {
+ 	MSI_FLAG_PCI_MSIX_ALLOC_DYN	= (1 << 20),
+ 	/* PCI MSIs cannot be steered separately to CPU cores */
+ 	MSI_FLAG_NO_AFFINITY		= (1 << 21),
++	/* Inhibit usage of entry masking */
++	MSI_FLAG_NO_MASK		= (1 << 22),
+ };
+ 
+ /**
+diff --git a/kernel/irq/msi.c b/kernel/irq/msi.c
+index 396a067a8a56..7682c36cbccc 100644
+--- a/kernel/irq/msi.c
++++ b/kernel/irq/msi.c
+@@ -1143,7 +1143,7 @@ static bool msi_check_reservation_mode(struct irq_domain *domain,
+ 	if (!(info->flags & MSI_FLAG_MUST_REACTIVATE))
+ 		return false;
+ 
+-	if (IS_ENABLED(CONFIG_PCI_MSI) && pci_msi_ignore_mask)
++	if (info->flags & MSI_FLAG_NO_MASK)
+ 		return false;
+ 
+ 	/*
+-- 
+2.48.1
+

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -150,6 +150,9 @@ Patch27: 0001-amdgpu-timeout.patch
 Patch28: 0001-iwlwifi-avoid-writing-to-MSI-X-page-when-MSI-X-is-no.patch
 Patch30: 0004-pvops-respect-removable-xenstore-flag-for-block-devi.patch
 Patch31: 0001-PCI-add-a-reset-quirk-for-Intel-I219LM-ethernet-adap.patch
+Patch32: 0001-xen-pci-Do-not-register-devices-with-segments-0x1000.patch
+Patch33: 0002-PCI-vmd-Disable-MSI-remapping-bypass-under-Xen.patch
+Patch34: 0003-PCI-MSI-Convert-pci_msi_ignore_mask-to-per-MSI-domai.patch
 
 # S0ix support:
 Patch61: xen-events-Add-wakeup-support-to-xen-pirq.patch


### PR DESCRIPTION
https://forum.qubes-os.org/t/how-to-disable-intel-volume-management-device-vmd-in-qubes-os-or-linux-kernel/32887/19
https://github.com/QubesOS/qubes-issues/issues/6932