### PR TITLE
Fix installing kernel headers

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -367,7 +367,7 @@ pushd %build_src_dir
 cp --parents `find  -type f -name "Makefile*" -o -name "Kconfig*"` %buildroot/lib/modules/%kernelrelease/build
 cp -a scripts %buildroot/lib/modules/%kernelrelease/build
 cp -a --parents arch/x86/include %buildroot/lib/modules/%kernelrelease/build/
-cp -a include %buildroot/lib/modules/%kernelrelease/build/include
+cp -a include %buildroot/lib/modules/%kernelrelease/build/
 popd
 
 cp Module.symvers %buildroot/lib/modules/%kernelrelease/build


### PR DESCRIPTION
Since 6.15 the include directory is created earlier (due having a
Makefile now), which made cp copy include into build/include/include.
Fix it by pointing cp at the parent directory instead.

Fixes QubesOS/qubes-issues#10057