### PR TITLE
kernel.spec.in: fix with_debuginfo missing %files entry

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -673,6 +673,9 @@ exit 0
 %if 0%{?fedora} >= 37
 %attr(0644, root, root) %vm_install_dir/memory-hotplug-supported
 %endif
+%if %{with_debuginfo}
+%{debuginfodir}/lib/modules/%kernelrelease/vmlinux
+%endif
 
 %changelog
 @CHANGELOG@


### PR DESCRIPTION
Match the vmlinux copy command with a corresponding %files entry to avoid the rpm build error when with_debuginfo is set.