### PR TITLE
Adjust for XSA-482, and also enable kernel memory profiling

### DIFF
--- a/config-qubes
+++ b/config-qubes
@@ -186,3 +186,9 @@ CONFIG_PHYSICAL_ALIGN=0x200000
 ## <https://lore.kernel.org/dri-devel/20251213054513.87925-1-superm1@kernel.org/t/#u>
 ## for details.
 # CONFIG_DRM_ACCEL_AMDXDNA is not set
+
+
+## Make it easy to debug memory issues, description says it's low overhead,
+## suitable for production. And configure it to require kernel cmdline opt-in.
+CONFIG_MEM_ALLOC_PROFILING=y
+# CONFIG_MEM_ALLOC_PROFILING_ENABLED_BY_DEFAULT is not set

--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -526,6 +526,8 @@ def_kernelopts="$def_kernelopts rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.ena
 %if 0%{?fedora} >= 37
 def_kernelopts="$def_kernelopts clocksource=tsc"
 %endif
+# (currently) required for vchan
+def_kernelopts="$def_kernelopts xen_privcmd.unrestricted"
 if [ -e /usr/lib/dracut/modules.d/90qubes-vm-simple/xen-scrub-pages-supported ]; then
     # set xen_scrub_pages=0 _only_ when included initramfs does support
     # re-enabling it


### PR DESCRIPTION
See commit messages for details.

As for memory profiling, the option description says it is suitable for production use (with minimal overhead), but still make it require kernel cmdline option to actually enable the feature.