### PR TITLE
disable OpenSSL engine usage

### DIFF
--- a/kernel.spec.in
+++ b/kernel.spec.in
@@ -71,9 +71,6 @@ BuildRequires:  bc
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 BuildRequires:  libuuid-devel
-%if 0%{?fedora} >= 41
-BuildRequires:  openssl-devel-engine
-%endif
 BuildRequires:  python3-devel
 BuildRequires:  gcc-plugin-devel
 BuildRequires:  elfutils-libelf-devel


### PR DESCRIPTION
OpenSSL 4.0 removed engine support.
Fedora 45+ will use OpenSSL 4.x, so prepare for it.